### PR TITLE
Create experimental multiarch target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@ services:
       - type: bind
         source: "${WORKDIR:-./}"
         target: /mnt/learncli
+  multiarch:
+    # From github.com:comp211/don/multiarch
+    image: learncli/multiarch:latest
+    working_dir: /mnt/learncli/workdir
+    volumes:
+      - type: bind
+        source: "${WORKDIR:-./}"
+        target: /mnt/learncli
   comp730:
     # From github.com:comp730-s23/comp730-container
     image: learncli/comp730:latest


### PR DESCRIPTION
This should work for everyone, but out of an abundance of caution, create a new multiarch target (amd64 and arm64). 

This is for ARM-based Mac users specifically.