### PR TITLE
Remove deprecated version directive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.2'
 services:
   bash:
     image: learncli/bash


### PR DESCRIPTION
This line is no longer needed, and causes a warning when one starts the container.  Remove it.