### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+# clang-format-all applies these settings to files in subdirectories of /mnt/learncli
+BasedOnStyle: Google
+# To match Vim settings
+IndentWidth: 4
+ObjCBlockIndentWidth: 4


### PR DESCRIPTION
This adds default settings for the `clang-format-all` command added in [this PR](https://github.com/comp211/comp211-container/pull/29).

I believe this file has to be added here and not at comp211-container because an instructor of 211/530 who isn't using these settings needs their students to change the file and have the changes persist. If this file is in comp211-container and copied into the container, then it'll overwrite whatever changes students make.