### PR TITLE
Vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,7 +1,8 @@
 " If this file is /root/.vimrc, changes will be cleared once you end your Docker session
-" To edit and have changes persist to the next session, edit /mnt/learncli/.vimrc
+" To edit and make changes apply in the next session, edit /mnt/learncli/.vimrc
 " In the current session, to allow vim to discover the changes made, copy /mnt/learncli/.vimrc to /root/.vimrc
-" Some keybinds are near the bottom of this file
+" This file is heavily documented, and some keybinds are near the bottom
+" If you edit this file and break some configuration, just roll back to the original vimrc
 
 set nocompatible
 
@@ -9,6 +10,8 @@ filetype off
 
 set rtp+=~/.vim/bundle/Vundle.vim
 
+" Plugins are automatically installed when container is built and when it's started
+" If adding any, use :PluginInstall to manually install
 call vundle#begin()
 Plugin 'VundleVim/Vundle.vim'
 Plugin 'airblade/vim-gitgutter'
@@ -65,6 +68,7 @@ let g:clang_format#style_options = {
 " Ctrl + O brings up a file menu
 " To learn how to use it, see https://github.com/preservim/nerdtree?tab=readme-ov-file#getting-started
 " And/or search for a NERDTree guide
+" Also, for tabs and window splitting, see https://gist.github.com/Starefossen/5957088
 map <C-o> :NERDTreeToggle<CR>
 
 " Map leader key <Leader> to Space

--- a/.vimrc
+++ b/.vimrc
@@ -1,3 +1,8 @@
+" If this file is /root/.vimrc, changes will be cleared once you end your Docker session
+" To edit and have changes persist to the next session, edit /mnt/learncli/.vimrc
+" In the current session, to allow vim to discover the changes made, copy /mnt/learncli/.vimrc to /root/.vimrc
+" Some keybinds are near the bottom of this file
+
 set nocompatible
 
 filetype off
@@ -8,13 +13,20 @@ call vundle#begin()
 Plugin 'VundleVim/Vundle.vim'
 Plugin 'airblade/vim-gitgutter'
 Plugin 'tpope/vim-surround'
+" File tree
 Plugin 'scrooloose/nerdtree'
 Plugin 'scrooloose/syntastic'
 Plugin 'rust-lang/rust.vim'
+" Code completion
 Plugin 'Valloric/YouCompleteMe'
 Plugin 'morhetz/gruvbox'
 Plugin 'itchyny/lightline.vim'
 Plugin 'rhysd/vim-clang-format'
+" Automatically close left chars (, [, { with the corresponding right char ), ], }
+Plugin 'jiangmiao/auto-pairs'
+" Navigate files easily, see https://github.com/easymotion/vim-easymotion
+" Our <leader> key is Space, so perform a search using Space + Space, e.g., Space + Space + w
+Plugin 'easymotion/vim-easymotion'
 call vundle#end()
 
 filetype plugin indent on
@@ -22,16 +34,18 @@ syntax on
 set tabstop=4
 set shiftwidth=4
 set expandtab
+" Comment this out to disable relative line numbering
+set relativenumber
 set number
-set encoding=utf-8 " For YouCompleteMe
-set laststatus=2 " For lightline.vim
-set t_u7= " Weird workaround
+set ignorecase
+set smartcase       " See https://vim.fandom.com/wiki/Searching#Case_sensitivity
+set encoding=utf-8  " For YouCompleteMe
+set laststatus=2    " For lightline.vim
+set t_u7=           " Weird workaround
 set t_RV=
 
 let g:ycm_confirm_extra_conf = 0
 let g:ycm_global_ycm_extra_conf = '~/.ycm_extra_conf.py'
-
-map <C-o> :NERDTreeToggle<CR>
 
 colorscheme gruvbox
 set background=dark
@@ -42,15 +56,19 @@ let g:syntastic_always_populate_loc_list = 1
 let g:syntastic_auto_loc_list = 1
 let g:syntastic_check_on_open = 1
 let g:syntastic_check_on_wq = 0
-let g:clang_format#code_style = "chromium" " The only predefined style with PointerAlignment Left
+let g:EasyMotion_smartcase = 1
+let g:clang_format#code_style = "google"
 let g:clang_format#style_options = {
     \ "IndentWidth" : 4,
     \ "ObjCBlockIndentWidth": 4}
 
+" Ctrl + O brings up a file menu
+" To learn how to use it, see https://github.com/preservim/nerdtree?tab=readme-ov-file#getting-started
+" And/or search for a NERDTree guide
+map <C-o> :NERDTreeToggle<CR>
+
 " Map leader key <Leader> to Space
 let mapleader = " "
-" map to <Leader>cf in C++ code
-autocmd FileType c,cpp,objc nnoremap <buffer><Leader>cf :<C-u>ClangFormat<CR>
-autocmd FileType c,cpp,objc vnoremap <buffer><Leader>cf :ClangFormat<CR>
-" Toggle auto formatting:
-nmap <Leader>C :ClangFormatAutoToggle<CR>
+" 2-character search motion, similar to vim-sneak
+nmap <Leader>s <Plug>(easymotion-s2)
+nmap <Leader>t <Plug>(easymotion-t2)

--- a/.vimrc
+++ b/.vimrc
@@ -66,13 +66,17 @@ let g:clang_format#style_options = {
     \ "ObjCBlockIndentWidth": 4}
 
 " Ctrl + O brings up a file menu
-" To learn how to use it, see https://github.com/preservim/nerdtree?tab=readme-ov-file#getting-started
-" And/or search for a NERDTree guide
+" To learn how to use NERDTree, see https://github.com/preservim/nerdtree?tab=readme-ov-file#getting-started
+" and/or search for a guide
 " Also, for tabs and window splitting, see https://gist.github.com/Starefossen/5957088
 map <C-o> :NERDTreeToggle<CR>
 
 " Map leader key <Leader> to Space
+" <Leader> is used in EasyMotion and can be used in other plugins
 let mapleader = " "
+
+" EasyMotion tutorial: https://www.barbarianmeetscoding.com/boost-your-coding-fu-with-vscode-and-vim/moving-even-faster-with-vim-sneak-and-easymotion/#vim-easymotion
+" and/or search for a guide
 " 2-character search motion, similar to vim-sneak
 nmap <Leader>s <Plug>(easymotion-s2)
 nmap <Leader>t <Plug>(easymotion-t2)

--- a/.vimrc
+++ b/.vimrc
@@ -66,8 +66,8 @@ let g:clang_format#style_options = {
     \ "ObjCBlockIndentWidth": 4}
 
 " Ctrl + O brings up a file menu
-" To learn how to use NERDTree, see https://github.com/preservim/nerdtree?tab=readme-ov-file#getting-started
-" and/or search for a guide
+" NERDTree guide: https://github.com/preservim/nerdtree?tab=readme-ov-file#getting-started
+" and/or Google about it
 " Also, for tabs and window splitting, see https://gist.github.com/Starefossen/5957088
 map <C-o> :NERDTreeToggle<CR>
 
@@ -75,8 +75,8 @@ map <C-o> :NERDTreeToggle<CR>
 " <Leader> is used in EasyMotion and can be used in other plugins
 let mapleader = " "
 
-" EasyMotion tutorial: https://www.barbarianmeetscoding.com/boost-your-coding-fu-with-vscode-and-vim/moving-even-faster-with-vim-sneak-and-easymotion/#vim-easymotion
-" and/or search for a guide
+" EasyMotion guide: https://www.barbarianmeetscoding.com/boost-your-coding-fu-with-vscode-and-vim/moving-even-faster-with-vim-sneak-and-easymotion/#vim-easymotion
+" and/or Google about it
 " 2-character search motion, similar to vim-sneak
 nmap <Leader>s <Plug>(easymotion-s2)
 nmap <Leader>t <Plug>(easymotion-t2)

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,56 @@
+set nocompatible
+
+filetype off
+
+set rtp+=~/.vim/bundle/Vundle.vim
+
+call vundle#begin()
+Plugin 'VundleVim/Vundle.vim'
+Plugin 'airblade/vim-gitgutter'
+Plugin 'tpope/vim-surround'
+Plugin 'scrooloose/nerdtree'
+Plugin 'scrooloose/syntastic'
+Plugin 'rust-lang/rust.vim'
+Plugin 'Valloric/YouCompleteMe'
+Plugin 'morhetz/gruvbox'
+Plugin 'itchyny/lightline.vim'
+Plugin 'rhysd/vim-clang-format'
+call vundle#end()
+
+filetype plugin indent on
+syntax on
+set tabstop=4
+set shiftwidth=4
+set expandtab
+set number
+set encoding=utf-8 " For YouCompleteMe
+set laststatus=2 " For lightline.vim
+set t_u7= " Weird workaround
+set t_RV=
+
+let g:ycm_confirm_extra_conf = 0
+let g:ycm_global_ycm_extra_conf = '~/.ycm_extra_conf.py'
+
+map <C-o> :NERDTreeToggle<CR>
+
+colorscheme gruvbox
+set background=dark
+set statusline+=%#warningmsg#
+set statusline+=%{SyntasticStatuslineFlag()}
+set statusline+=%*
+let g:syntastic_always_populate_loc_list = 1
+let g:syntastic_auto_loc_list = 1
+let g:syntastic_check_on_open = 1
+let g:syntastic_check_on_wq = 0
+let g:clang_format#code_style = "chromium" " The only predefined style with PointerAlignment Left
+let g:clang_format#style_options = {
+    \ "IndentWidth" : 4,
+    \ "ObjCBlockIndentWidth": 4}
+
+" Map leader key <Leader> to Space
+let mapleader = " "
+" map to <Leader>cf in C++ code
+autocmd FileType c,cpp,objc nnoremap <buffer><Leader>cf :<C-u>ClangFormat<CR>
+autocmd FileType c,cpp,objc vnoremap <buffer><Leader>cf :ClangFormat<CR>
+" Toggle auto formatting:
+nmap <Leader>C :ClangFormatAutoToggle<CR>


### PR DESCRIPTION
This PR should be considered to be part of https://github.com/comp211/comp211-container/pull/28.

If this PR and that PR are merged, then users can edit `/mnt/learncli/.vimrc` to have changes persist across sessions. This is necessary this semester because students may not like relative line numbering, which is made default in the above PR.